### PR TITLE
Refractor of some codes

### DIFF
--- a/Background.js
+++ b/Background.js
@@ -1,27 +1,62 @@
-let SpecificWebsites = ["https://g00gle.com/", "https://www.g00gle.com/"];
-let originalUrl = null; // Store the original URL
-let userContinued = false; // Flag to indicate whether the user has chosen to continue
+// Detect browser platform for cross-browser compactibility
+let API;
+let platform;
+
+if (typeof chrome !== 'undefined') {
+    API = chrome;
+    platform = "chrome";
+} else if (typeof browser != 'undefined') {
+    API = browser;
+    platform = "firefox"
+} else {
+    throw new Error("Unsupported browser.")
+}
+
+// Scam -> Legitimate
+let SpecificWebsites = {
+    "g00gle.com": "google.com",
+};
+
+// Whether a "scam" website is allowed to visit
+// This does not survive restarts
+let trustedScams = [];
 
 function isSpecificWebsite(url) {
-    return SpecificWebsites.includes(url);
+    return SpecificWebsites.hasOwnProperty(url);
 }
 
-function warningPage(tabId) {
-    chrome.tabs.update(tabId, {url: "Warning.html"});
+function getURL(original_hostname, original_url, legitimate_url) {
+    const baseURL = API.runtime.getURL('Warning.html');
+    const parameters = new URLSearchParams({
+        host: original_hostname,
+        orig: original_url,
+        leg: legitimate_url
+    });
+
+    return `${baseURL}?${parameters.toString()}`;
 }
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-    if (changeInfo.url && isSpecificWebsite(changeInfo.url) && !userContinued) {
-        originalUrl = changeInfo.url; // Store the original URL before redirecting
-        warningPage(tabId);
-    } else {
-        userContinued = false; // Reset the flag when navigating to a different website
+API.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+    if (typeof changeInfo.url != 'string') {
+        return;
+    }
+    const old_URL = new URL(changeInfo.url);
+    const hostname = old_URL.hostname;
+    if (isSpecificWebsite(hostname) && !trustedScams.includes(hostname)) {
+        let legitimate_url_obj = new URL(old_URL);
+        legitimate_url_obj.hostname = SpecificWebsites[hostname];
+        const legitimate_url = legitimate_url_obj.toString();
+
+        const warning_url = getURL(hostname, changeInfo.url, legitimate_url);
+        API.tabs.update(tabId, {url: warning_url});
     }
 });
 
-chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
-    if (request.method === "getOriginalUrl") {
-        userContinued = true; // Set the flag when the user chooses to continue
-        sendResponse({url: originalUrl});
+API.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    if (request.method === "P04SetTrust") {
+        if (!trustedScams.includes(request.hostname)) {
+            trustedScams.push(request.hostname);
+        }
+        sendResponse({});
     }
 });

--- a/Warning.js
+++ b/Warning.js
@@ -1,13 +1,39 @@
+// Detect browser platform for cross-browser compactibility
+let API;
+let platform;
+
+if (typeof chrome !== 'undefined') {
+    API = chrome;
+    platform = "chrome";
+} else if (typeof browser != 'undefined') {
+    API = browser;
+    platform = "firefox"
+} else {
+    throw new Error("Unsupported browser.")
+}
+
+const searchParams = new URLSearchParams(window.location.search);
+
 document.getElementById('Safe').addEventListener('click', function() {
-    chrome.tabs.update({url: 'https://1.1.1.1'});
+    window.location.assign('https://1.1.1.1');
 });
 
 document.getElementById('Correct').addEventListener('click', function() {
-    chrome.tabs.update({url: 'https://www.google.com'});
+    const hostname = searchParams.get('leg');
+    console.log(`Going to ${hostname}`);
+    window.location.assign(hostname);
 });
 
 document.getElementById('Continue').addEventListener('click', function() {
-    chrome.runtime.sendMessage({method: "getOriginalUrl"}, function(response) {
-        chrome.tabs.update({url: response.url});
+    const request = {
+        method: "P04SetTrust",
+        hostname: searchParams.get('host'),
+    }
+    API.runtime.sendMessage(request, function(response) {
+        const hostname = searchParams.get('orig');
+        console.log(`Going to ${hostname}`);
+        window.location.assign(hostname);
     });
 });
+
+console.log("Warning script loaded");

--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
         "https://*/*"
     ],
     "background": {
-        "service_worker": "Background.js"
+        "service_worker": "Background.js",
+        "scripts": ["Background.js"]
     }
 }


### PR DESCRIPTION
This PR contains these changes:

1. A constant, `API`, is defined based on the browser platform to provide cross-browser compatibility. It is currently implemented for Chrome (or any Chromium-based browser like Edge) and Firefox.
2. The list of "specific websites" is now defined with a dictionary (or Object). Also, the key is changed from absolute URL to hostname - this allows catching any pages on that host.
3. The website redirection targets are now passed into the warning page as search parameters. This avoids collisions caused by opening different "scam" websites together.

This PR is tested on Chromium and Firefox and is ready for review.

BTW, I see the opportunity of integrating our project, [BCHostTrust](https://github.com/BCHostTrust/bchosttrust/), into yours (of course, after finishing the must-dos like the [block distribution system](https://github.com/BCHostTrust/bchosttrust/issues/5)).